### PR TITLE
feat: PersonalPage 체크리스트 기능 구현

### DIFF
--- a/src/components/card-list/CardList.jsx
+++ b/src/components/card-list/CardList.jsx
@@ -1,3 +1,4 @@
+import React, { useEffect, useRef, useCallback } from 'react';
 import MessageCard from '../card/MessageCard';
 import { CardlistContainer } from './CardList.styled';
 import AddCard from '../card/CardAdd';
@@ -7,20 +8,46 @@ export default function CardList({
   isEditing,
   onDeleteMessage,
   onClickAdd,
+  onCardClick,
+  loading,
+  hasMore,
+  onLoadMore,
 }) {
+  const observerRef = useRef();
+  const lastMessageElementRef = useRef();
+
+  // 무한 스크롤을 위한 Intersection Observer 설정
+  const lastMessageRef = useCallback(node => {
+    if (loading) return;
+    if (observerRef.current) observerRef.current.disconnect();
+    
+    observerRef.current = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting && hasMore && onLoadMore) {
+        onLoadMore();
+      }
+    });
+    
+    if (node) observerRef.current.observe(node);
+  }, [loading, hasMore, onLoadMore]);
+
   return (
     <CardlistContainer>
       {!isEditing && <AddCard onClickAdd={onClickAdd} />}
-      {messages.map(
-        ({
+      {messages.map((message, index) => {
+        const {
           id: messageId,
           profileImageURL,
           relationship,
           sender,
           content,
           createdAt,
-        }) => (
+        } = message;
+        
+        const isLastMessage = index === messages.length - 1;
+        
+        return (
           <MessageCard
+            ref={isLastMessage ? lastMessageRef : null}
             messageId={messageId}
             key={messageId}
             profileImage={profileImageURL}
@@ -30,8 +57,14 @@ export default function CardList({
             date={createdAt}
             isEditing={isEditing}
             onDelete={onDeleteMessage}
+            onClick={() => onCardClick && onCardClick(message)}
           />
-        ),
+        );
+      })}
+      {loading && (
+        <div style={{ textAlign: 'center', padding: '20px', gridColumn: '1 / -1' }}>
+          로딩 중...
+        </div>
       )}
     </CardlistContainer>
   );

--- a/src/components/card/CardModal.jsx
+++ b/src/components/card/CardModal.jsx
@@ -1,0 +1,181 @@
+import React, { useEffect } from 'react';
+import styled from 'styled-components';
+import defaultProfile from '../../assets/svg/default_profile.svg';
+
+const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+`;
+
+const ModalContent = styled.div`
+  width: 600px;
+  height: 476px;
+  padding: 40px;
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+  position: relative;
+
+  @media (max-width: 768px) {
+    width: 90%;
+    max-width: 500px;
+    height: auto;
+    padding: 24px;
+  }
+`;
+
+const CloseButton = styled.button`
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #666;
+  
+  &:hover {
+    color: #333;
+  }
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #ddd;
+`;
+
+const ProfileImage = styled.div`
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #888 0%, #666 100%);
+  margin-right: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+`;
+
+const HeaderInfo = styled.div`
+  flex: 1;
+`;
+
+const FromText = styled.h2`
+  font-size: 20px;
+  font-weight: 400;
+  margin: 0 0 6px 0;
+  color: #000000;
+`;
+
+const NameText = styled.span`
+  font-size: 20px;
+  font-weight: 700;
+  color: #000000;
+`;
+
+const StatusBadge = styled.div`
+  display: inline-block;
+  background: #f8f0ff;
+  color: #9935ff;
+  padding: 0px 8px;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+`;
+
+const MessageContent = styled.div`
+  height: 280px;
+  margin-bottom: 16px;
+  overflow-y: auto;
+  padding-right: 8px;
+
+  @media (max-width: 768px) {
+    height: 200px;
+  }
+`;
+
+const MessageText = styled.p`
+  font-size: 18px;
+  line-height: 28px;
+  color: #4a4a4a;
+  font-weight: 400;
+  white-space: pre-wrap;
+  word-break: break-word;
+`;
+
+const DateText = styled.div`
+  font-size: 12px;
+  color: #999999;
+  font-weight: 400;
+`;
+
+const CardModal = ({ card, onClose }) => {
+  useEffect(() => {
+    const handleEscape = (e) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [onClose]);
+
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  if (!card) return null;
+
+  return (
+    <ModalOverlay onClick={handleOverlayClick}>
+      <ModalContent>
+        <CloseButton onClick={onClose}>×</CloseButton>
+        
+        <Header>
+          <ProfileImage>
+            {card.profileImageURL ? (
+              <img src={card.profileImageURL} alt="Profile" />
+            ) : (
+              <img src={defaultProfile} alt="Profile" />
+            )}
+          </ProfileImage>
+          <HeaderInfo>
+            <FromText>
+              From. <NameText>{card.sender}</NameText>
+            </FromText>
+            <StatusBadge>{card.relationship}</StatusBadge>
+          </HeaderInfo>
+        </Header>
+
+        <MessageContent>
+          <MessageText>{card.content}</MessageText>
+        </MessageContent>
+
+        <DateText>{new Date(card.createdAt).toLocaleDateString()}</DateText>
+      </ModalContent>
+    </ModalOverlay>
+  );
+};
+
+export default CardModal;

--- a/src/components/card/MessageCard.jsx
+++ b/src/components/card/MessageCard.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import styled from 'styled-components';
 import Button from '../button/Button.jsx';
 import defaultProfile from '../../assets/svg/default_profile.svg';
@@ -18,7 +18,7 @@ import {
 
 //삭제로직
 
-const MessageCard = ({
+const MessageCard = forwardRef(({
   messageId,
   profileImage,
   name = '김동훈',
@@ -27,10 +27,15 @@ const MessageCard = ({
   date = '2025.07.12',
   isEditing,
   onDelete,
-}) => {
+  onClick,
+}, ref) => {
   const formattedDate = formatDate(date);
   return (
-    <CardContainer>
+    <CardContainer 
+      ref={ref} 
+      onClick={onClick} 
+      style={{ cursor: onClick ? 'pointer' : 'default' }}
+    >
       <Header>
         <ProfileImage>
           {profileImage ? (
@@ -46,7 +51,13 @@ const MessageCard = ({
           <StatusBadge $status={status}>{status}</StatusBadge>
         </HeaderInfo>
         {isEditing && (
-          <Button onClick={() => onDelete(messageId)} variant="icon">
+          <Button 
+            onClick={(e) => {
+              e.stopPropagation(); // 카드 클릭 이벤트 방지
+              onDelete(messageId);
+            }} 
+            variant="icon"
+          >
             🗑️
           </Button>
         )}
@@ -59,6 +70,6 @@ const MessageCard = ({
       <DateText>{formattedDate}</DateText>
     </CardContainer>
   );
-};
+});
 
 export default MessageCard;

--- a/src/components/modal/CardModal.jsx
+++ b/src/components/modal/CardModal.jsx
@@ -1,0 +1,200 @@
+import React, { useEffect } from 'react';
+import styled from 'styled-components';
+import defaultProfile from '../../assets/svg/default_profile.svg';
+
+const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  padding: 20px;
+`;
+
+const ModalContent = styled.div`
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+  max-width: 600px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+`;
+
+const CloseButton = styled.button`
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #666;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  
+  &:hover {
+    background-color: #f5f5f5;
+  }
+`;
+
+const CardContainer = styled.div`
+  padding: 60px 40px 40px;
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 24px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #ddd;
+`;
+
+const ProfileImage = styled.div`
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #888 0%, #666 100%);
+  margin-right: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+`;
+
+const HeaderInfo = styled.div`
+  flex: 1;
+`;
+
+const FromText = styled.h2`
+  font-size: 24px;
+  font-weight: 400;
+  margin: 0 0 8px 0;
+  color: #000000;
+`;
+
+const NameText = styled.span`
+  font-size: 24px;
+  font-weight: 700;
+  color: #000000;
+`;
+
+const StatusBadge = styled.div`
+  display: inline-block;
+  background: #f8f0ff;
+  color: #9935ff;
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 24px;
+`;
+
+const MessageContent = styled.div`
+  min-height: 150px;
+  margin-bottom: 24px;
+`;
+
+const MessageText = styled.p`
+  font-size: 20px;
+  line-height: 32px;
+  color: #4a4a4a;
+  font-weight: 400;
+  margin: 0;
+  white-space: pre-wrap;
+`;
+
+const DateText = styled.div`
+  font-size: 14px;
+  color: #999999;
+  font-weight: 400;
+  text-align: right;
+`;
+
+const CardModal = ({ card, onClose }) => {
+  if (!card) return null;
+
+  // ESC 키로 모달 닫기
+  useEffect(() => {
+    const handleEscKey = (e) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscKey);
+    return () => document.removeEventListener('keydown', handleEscKey);
+  }, [onClose]);
+
+  // 스크롤 방지
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, []);
+
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  const formatDate = (dateString) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).replace(/\. /g, '.').replace(/\.$/, '');
+  };
+
+  return (
+    <ModalOverlay onClick={handleOverlayClick}>
+      <ModalContent>
+        <CloseButton onClick={onClose}>×</CloseButton>
+        <CardContainer>
+          <Header>
+            <ProfileImage>
+              {card.profileImageURL ? (
+                <img src={card.profileImageURL} alt="Profile" />
+              ) : (
+                <img src={defaultProfile} alt="Profile" />
+              )}
+            </ProfileImage>
+            <HeaderInfo>
+              <FromText>
+                From. <NameText>{card.sender}</NameText>
+              </FromText>
+              <StatusBadge>{card.relationship}</StatusBadge>
+            </HeaderInfo>
+          </Header>
+
+          <MessageContent>
+            <MessageText>{card.content}</MessageText>
+          </MessageContent>
+
+          <DateText>{formatDate(card.createdAt)}</DateText>
+        </CardContainer>
+      </ModalContent>
+    </ModalOverlay>
+  );
+};
+
+export default CardModal;

--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useAsync } from './useAsync.js';
+import useAsync from './useAsync.js';
 
 /**
  * GET 요청을 위한 범용 커스텀 훅

--- a/src/pages/PersonalPage.stories.jsx
+++ b/src/pages/PersonalPage.stories.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
+import PersonalPage, { mockData } from './PersonalPage';
+import Theme from '../styles/theme';
+import GlobalStyle from '../styles/GlobalStyle';
+
+export default {
+  title: 'Pages/PersonalPage',
+  component: PersonalPage,
+  decorators: [
+    (Story) => (
+      <ThemeProvider theme={Theme}>
+        <GlobalStyle />
+        <BrowserRouter>
+          <div style={{ minHeight: '100vh', backgroundColor: '#f8f9fa' }}>
+            <Story />
+          </div>
+        </BrowserRouter>
+      </ThemeProvider>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+// Mock API 함수들
+const mockAPI = {
+  getRecipient: () => Promise.resolve(mockData),
+  getMessageList: () => Promise.resolve({
+    results: mockData.recentMessages,
+    next: null,
+  }),
+  deleteRecipient: () => Promise.resolve(),
+  deleteMessage: () => Promise.resolve(),
+};
+
+// API 모킹
+jest.mock('../api/recipients', () => mockAPI);
+jest.mock('../api/messages', () => mockAPI);
+
+export const Default = {
+  args: {},
+  parameters: {
+    reactRouter: {
+      routePath: '/post/:id',
+      routeParams: { id: '12321' },
+      location: { pathname: '/post/12321' },
+    },
+  },
+};
+
+export const EditMode = {
+  args: {},
+  parameters: {
+    reactRouter: {
+      routePath: '/post/:id/edit',
+      routeParams: { id: '12321' },
+      location: { pathname: '/post/12321/edit' },
+    },
+  },
+};
+
+export const WithManyMessages = {
+  args: {},
+  parameters: {
+    reactRouter: {
+      routePath: '/post/:id',
+      routeParams: { id: '12321' },
+      location: { pathname: '/post/12321' },
+    },
+  },
+  beforeEach: () => {
+    // 더 많은 메시지가 있는 상황 모킹
+    const extendedMessages = [
+      ...mockData.recentMessages,
+      ...Array.from({ length: 20 }, (_, i) => ({
+        id: 50000 + i,
+        recipientId: 12321,
+        sender: `사용자 ${i + 1}`,
+        profileImageURL: `https://i.pravatar.cc/100?img=${(i % 70) + 1}`,
+        relationship: ['친구', '동료', '가족', '지인'][i % 4],
+        content: `이것은 테스트 메시지 ${i + 1}번입니다. 스토리북에서 무한 스크롤을 테스트하기 위한 더미 데이터입니다.`,
+        font: 'Pretendard',
+        createdAt: new Date(Date.now() - i * 1000 * 60 * 60).toISOString(),
+      })),
+    ];
+
+    jest.doMock('../api/messages', () => ({
+      ...mockAPI,
+      getMessageList: (recipientId, options = {}) => {
+        const { offset = 0, limit = 8 } = options;
+        const start = offset;
+        const end = start + limit;
+        return Promise.resolve({
+          results: extendedMessages.slice(start, end),
+          next: end < extendedMessages.length ? `next-page-${end}` : null,
+        });
+      },
+    }));
+  },
+};


### PR DESCRIPTION
- 카드 목록 '최신순'으로 무한 스크롤 방식으로 배치
- 카드 클릭 시 해당 카드 확대되어 보이는 모달 기능
- + 버튼 클릭 시 /post/{id}/message로 이동
- PC에서 헤더/카드 목록 영역 반응형 디자인 (1248px 기준)

구현 내용:
- PersonalPage: 무한 스크롤, 카드 클릭, 모달 관리 state 및 핸들러 추가
- CardModal: 새로 생성된 카드 확대 모달 컴포넌트
- CardList: Intersection Observer를 활용한 무한 스크롤 및 카드 클릭 이벤트 지원
- MessageCard: forwardRef로 ref 전달 및 클릭 이벤트 지원
- 반응형 스타일: 1248px 기준점으로 PC/모바일 대응

기존 Subheader 컴포넌트는 수정하지 않고 보존